### PR TITLE
Remove Debounce API usage

### DIFF
--- a/email_validator_tool/validators/bounce_list.py
+++ b/email_validator_tool/validators/bounce_list.py
@@ -1,8 +1,7 @@
 import sqlite3
 from pathlib import Path
-from email_validator_tool.core.models import ValidationResult, ValidationStatus
-import aiohttp
 from loguru import logger
+from email_validator_tool.core.models import ValidationResult, ValidationStatus
 
 DB_PATH = Path("bounce_list.db")
 
@@ -23,10 +22,18 @@ def setup_database():
 class BounceListValidator:
     """Validator for checking if an email is in a bounce list"""
     
-    def __init__(self):
-        """Initialize the validator"""
-        self.api_url = "https://bounce.debounce.io/v1/bounce"
-        self.api_key = None  # Set your API key here
+    def __init__(self, db_path: Path = DB_PATH):
+        """Initialize the validator using a local SQLite database."""
+        self.db_path = db_path
+        setup_database(self.db_path)
+
+    def add_email(self, email: str) -> None:
+        """Add an email to the local bounce list."""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("INSERT OR IGNORE INTO bounces (email) VALUES (?)", (email,))
+        conn.commit()
+        conn.close()
     
     async def validate(self, email: str) -> ValidationResult:
         """
@@ -41,33 +48,22 @@ class BounceListValidator:
         try:
             logger.debug(f"Checking if {email} is in bounce list")
             
-            async with aiohttp.ClientSession() as session:
-                params = {'email': email}
-                if self.api_key:
-                    params['api_key'] = self.api_key
-                    
-                async with session.get(self.api_url, params=params) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        if data.get('bounce'):
-                            logger.warning(f"Email {email} is in bounce list")
-                            return ValidationResult(
-                                email=email,
-                                status=ValidationStatus.ON_BOUNCE_LIST,
-                                details="Email is in bounce list"
-                            )
-                        logger.info(f"Email {email} is not in bounce list")
-                        return ValidationResult(
-                            email=email,
-                            status=ValidationStatus.VALID
-                        )
-                    else:
-                        logger.error(f"Error checking bounce status: {response.status}")
-                        return ValidationResult(
-                            email=email,
-                            status=ValidationStatus.UNKNOWN_ERROR,
-                            details=f"API error: {response.status}"
-                        )
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1 FROM bounces WHERE email = ?", (email,))
+            row = cursor.fetchone()
+            conn.close()
+
+            if row:
+                logger.warning(f"Email {email} is in bounce list")
+                return ValidationResult(
+                    email=email,
+                    status=ValidationStatus.ON_BOUNCE_LIST,
+                    details="Email is in bounce list",
+                )
+
+            logger.info(f"Email {email} is not in bounce list")
+            return ValidationResult(email=email, status=ValidationStatus.VALID)
                         
         except Exception as e:
             logger.error(f"Error validating bounce status for {email}: {str(e)}")

--- a/email_validator_tool/validators/catch_all.py
+++ b/email_validator_tool/validators/catch_all.py
@@ -1,13 +1,12 @@
 import random
 import string
 import aiosmtplib
-import aiohttp
+import dns.resolver
 from email.mime.text import MIMEText
 from loguru import logger
 from email_validator_tool.core.models import ValidationResult, ValidationStatus
 from email_validator_tool.config import Settings
 
-SETTINGS = Settings()
 
 def generate_random_email(domain: str) -> str:
     """Generate a random email address for the given domain."""
@@ -18,9 +17,8 @@ class CatchAllValidator:
     """Validator for checking if a domain has catch-all enabled"""
     
     def __init__(self):
-        """Initialize the validator"""
-        self.api_url = "https://catchall.debounce.io/v1/catchall"
-        self.api_key = None  # Set your API key here
+        """Initialize the validator without external API."""
+        self.settings = Settings()
     
     async def validate(self, email: str) -> ValidationResult:
         """
@@ -36,33 +34,66 @@ class CatchAllValidator:
             domain = email.split('@')[1]
             logger.debug(f"Checking if domain {domain} has catch-all enabled")
             
-            async with aiohttp.ClientSession() as session:
-                params = {'email': email}
-                if self.api_key:
-                    params['api_key'] = self.api_key
-                    
-                async with session.get(self.api_url, params=params) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        if data.get('catchall'):
-                            logger.warning(f"Domain {domain} has catch-all enabled")
-                            return ValidationResult(
-                                email=email,
-                                status=ValidationStatus.CATCH_ALL,
-                                details="Domain has catch-all enabled"
-                            )
-                        logger.info(f"Domain {domain} does not have catch-all enabled")
+            if not self.settings.ENABLE_CATCH_ALL:
+                logger.debug("Catch-all check disabled in settings")
+                return ValidationResult(email=email, status=ValidationStatus.VALID)
+
+            try:
+                mx_records = dns.resolver.resolve(domain, 'MX')
+                if not mx_records:
+                    return ValidationResult(
+                        email=email,
+                        status=ValidationStatus.INVALID_MX,
+                        details="No MX records found",
+                    )
+            except dns.resolver.NXDOMAIN:
+                return ValidationResult(
+                    email=email,
+                    status=ValidationStatus.INVALID_DOMAIN,
+                    details="Domain does not exist",
+                )
+            except dns.resolver.NoAnswer:
+                return ValidationResult(
+                    email=email,
+                    status=ValidationStatus.INVALID_MX,
+                    details="No MX records found",
+                )
+
+            mx_host = str(mx_records[0].exchange)
+            random_email = generate_random_email(domain)
+
+            try:
+                async with aiosmtplib.SMTP(
+                    hostname=mx_host,
+                    port=self.settings.SMTP_PORT,
+                    timeout=self.settings.SMTP_TIMEOUT,
+                ) as smtp:
+                    await smtp.ehlo()
+                    await smtp.mail(f"verify@{domain}")
+                    response = await smtp.rcpt(random_email)
+                    if response.code == 250:
+                        logger.warning(f"Domain {domain} has catch-all enabled")
                         return ValidationResult(
                             email=email,
-                            status=ValidationStatus.VALID
+                            status=ValidationStatus.CATCH_ALL,
+                            details="Domain has catch-all enabled",
                         )
+                    elif response.code == 550:
+                        logger.info(f"Domain {domain} does not have catch-all enabled")
+                        return ValidationResult(email=email, status=ValidationStatus.VALID)
                     else:
-                        logger.error(f"Error checking catch-all status: {response.status}")
                         return ValidationResult(
                             email=email,
                             status=ValidationStatus.UNKNOWN_ERROR,
-                            details=f"API error: {response.status}"
+                            details=f"Unexpected SMTP code {response.code}",
                         )
+            except aiosmtplib.SMTPException as exc:
+                logger.error(f"SMTP error during catch-all check: {exc}")
+                return ValidationResult(
+                    email=email,
+                    status=ValidationStatus.UNKNOWN_ERROR,
+                    details=f"SMTP error: {str(exc)}",
+                )
                         
         except Exception as e:
             logger.error(f"Error validating catch-all status for {email}: {str(e)}")

--- a/email_validator_tool/validators/disposable.py
+++ b/email_validator_tool/validators/disposable.py
@@ -1,14 +1,22 @@
-import aiohttp
 from loguru import logger
 from email_validator_tool.core.models import ValidationResult, ValidationStatus
 
 class DisposableValidator:
-    """Validator for disposable email domains"""
-    
+    """Validator for disposable email domains."""
+
     def __init__(self):
-        """Initialize the validator"""
-        self.api_url = "https://disposable.debounce.io/v1/disposable"
-        self.api_key = None  # Set your API key here
+        """Initialize the validator without requiring any API."""
+        self.disposable_domains = {
+            "mailinator.com",
+            "tempmail.com",
+            "10minutemail.com",
+            "throwawaymail.com",
+            "guerrillamail.com",
+            "trashmail.com",
+            "yopmail.com",
+            "maildrop.cc",
+            "getnada.com",
+        }
     
     async def validate(self, email: str) -> ValidationResult:
         """
@@ -21,36 +29,19 @@ class DisposableValidator:
             ValidationResult with the validation outcome
         """
         try:
-            domain = email.split('@')[1]
+            domain = email.split('@')[1].lower()
             logger.debug(f"Checking if domain {domain} is disposable")
+            if domain in self.disposable_domains:
+                logger.warning(f"Domain {domain} is disposable")
+                return ValidationResult(
+                    email=email,
+                    status=ValidationStatus.DISPOSABLE,
+                    details="Domain is disposable",
+                )
+
+            logger.info(f"Domain {domain} is not disposable")
+            return ValidationResult(email=email, status=ValidationStatus.VALID)
             
-            async with aiohttp.ClientSession() as session:
-                params = {'email': email}
-                if self.api_key:
-                    params['api_key'] = self.api_key
-                    
-                async with session.get(self.api_url, params=params) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        if data.get('disposable'):
-                            logger.warning(f"Domain {domain} is disposable")
-                            return ValidationResult(
-                                email=email,
-                                status=ValidationStatus.DISPOSABLE,
-                                details="Domain is disposable"
-                            )
-                        logger.info(f"Domain {domain} is not disposable")
-                        return ValidationResult(
-                            email=email,
-                            status=ValidationStatus.VALID
-                        )
-                    else:
-                        logger.error(f"Error checking disposable status: {response.status}")
-                        return ValidationResult(
-                            email=email,
-                            status=ValidationStatus.UNKNOWN_ERROR,
-                            details=f"API error: {response.status}"
-                        )
                         
         except Exception as e:
             logger.error(f"Error validating disposable status for {email}: {str(e)}")

--- a/email_validator_tool/validators/dns_mx.py
+++ b/email_validator_tool/validators/dns_mx.py
@@ -43,3 +43,8 @@ class DNSMXValidator:
                 status=ValidationStatus.UNKNOWN_ERROR,
                 details=f"DNS error: {str(exc)}"
             )
+
+async def check(email: str) -> ValidationResult:
+    """Convenience wrapper to validate a single email."""
+    return await DNSMXValidator().validate(email)
+

--- a/email_validator_tool/validators/syntax.py
+++ b/email_validator_tool/validators/syntax.py
@@ -28,3 +28,8 @@ class SyntaxValidator:
                 status=ValidationStatus.UNKNOWN_ERROR,
                 details=f"Syntax validation error: {str(e)}"
             )
+
+async def check(email: str) -> ValidationResult:
+    """Convenience wrapper to validate a single email."""
+    return await SyntaxValidator().validate(email)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,14 @@
 Common test fixtures for email validator tests.
 """
 
+import sys
+from pathlib import Path
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 from email_validator_tool.core.results import ValidationResult
-from email_validator_tool.core.pipeline import ValidationPipeline
 
 @pytest.fixture
 def valid_email():
@@ -31,7 +36,3 @@ def validation_result():
     """Return a ValidationResult instance for testing."""
     return ValidationResult()
 
-@pytest.fixture
-def validation_pipeline():
-    """Return a ValidationPipeline instance for testing."""
-    return ValidationPipeline()

--- a/tests/test_bounce_list.py
+++ b/tests/test_bounce_list.py
@@ -1,35 +1,14 @@
-"""
-Tests for the bounce list validator.
-"""
-
+import tempfile
+from pathlib import Path
 import pytest
 from email_validator_tool.validators.bounce_list import BounceListValidator
+from email_validator_tool.core.models import ValidationStatus
 
-def test_bounce_list_validator_initialization():
-    """Test bounce list validator initialization."""
-    validator = BounceListValidator()
-    assert validator is not None
-    assert validator.name == "bounce_list"
-
-def test_bounce_list_validation(valid_email, validation_result):
-    """Test bounce list validation with a valid email."""
-    validator = BounceListValidator()
-    result = validator.validate(valid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is True
-
-def test_bounce_list_validation_with_bounced_email(validation_result):
-    """Test bounce list validation with a bounced email."""
-    validator = BounceListValidator()
-    # Add a test bounced email to the list
-    validator.bounce_list.add("bounced@example.com")
-    result = validator.validate("bounced@example.com", validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_bounce_list_validation_with_invalid_email(invalid_email, validation_result):
-    """Test bounce list validation with an invalid email."""
-    validator = BounceListValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
+@pytest.mark.asyncio
+async def test_bounce_list_detection():
+    tmp = Path(tempfile.mkstemp()[1])
+    validator = BounceListValidator(db_path=tmp)
+    validator.add_email("bounced@example.com")
+    result = await validator.validate("bounced@example.com")
+    assert result.status == ValidationStatus.ON_BOUNCE_LIST
+    tmp.unlink()

--- a/tests/test_catch_all.py
+++ b/tests/test_catch_all.py
@@ -1,33 +1,10 @@
-"""
-Tests for the catch-all email validator.
-"""
-
 import pytest
 from email_validator_tool.validators.catch_all import CatchAllValidator
+from email_validator_tool.core.models import ValidationStatus
 
-def test_catch_all_validator_initialization():
-    """Test catch-all validator initialization."""
+@pytest.mark.asyncio
+async def test_catch_all_disabled_returns_valid():
     validator = CatchAllValidator()
-    assert validator is not None
-    assert validator.name == "catch_all"
-
-def test_catch_all_validation(valid_email, validation_result):
-    """Test catch-all validation with a valid email."""
-    validator = CatchAllValidator()
-    result = validator.validate(valid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is True
-
-def test_catch_all_validation_with_invalid_domain(invalid_email, validation_result):
-    """Test catch-all validation with an invalid domain."""
-    validator = CatchAllValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_catch_all_validation_with_nonexistent_domain(validation_result):
-    """Test catch-all validation with a nonexistent domain."""
-    validator = CatchAllValidator()
-    result = validator.validate("test@nonexistentdomain123456.com", validation_result)
-    assert isinstance(result, bool)
-    assert result is False
+    validator.settings.ENABLE_CATCH_ALL = False
+    result = await validator.validate("user@example.com")
+    assert result.status == ValidationStatus.VALID

--- a/tests/test_disposable.py
+++ b/tests/test_disposable.py
@@ -1,49 +1,15 @@
-"""
-Tests for the disposable email validator.
-"""
-
 import pytest
-from email_validator_tool.validators.disposable import DisposableEmailValidator
+from email_validator_tool.validators.disposable import DisposableValidator
+from email_validator_tool.core.models import ValidationStatus
 
-def test_disposable_validator_initialization():
-    """Test disposable email validator initialization."""
-    validator = DisposableEmailValidator()
-    assert validator is not None
-    assert validator.name == "disposable"
+@pytest.mark.asyncio
+async def test_disposable_detected():
+    validator = DisposableValidator()
+    result = await validator.validate("user@mailinator.com")
+    assert result.status == ValidationStatus.DISPOSABLE
 
-def test_disposable_validation(valid_email, validation_result):
-    """Test disposable email validation with a valid email."""
-    validator = DisposableEmailValidator()
-    result = validator.validate(valid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is True
-
-def test_disposable_validation_with_disposable_email(disposable_email, validation_result):
-    """Test disposable email validation with a disposable email."""
-    validator = DisposableEmailValidator()
-    result = validator.validate(disposable_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_disposable_validation_with_common_disposable_domains(validation_result):
-    """Test disposable email validation with common disposable domains."""
-    validator = DisposableEmailValidator()
-    disposable_domains = [
-        "mailinator.com",
-        "tempmail.com",
-        "throwawaymail.com",
-        "guerrillamail.com",
-        "10minutemail.com"
-    ]
-    for domain in disposable_domains:
-        email = f"test@{domain}"
-        result = validator.validate(email, validation_result)
-        assert isinstance(result, bool)
-        assert result is False
-
-def test_disposable_validation_with_invalid_email(invalid_email, validation_result):
-    """Test disposable email validation with an invalid email."""
-    validator = DisposableEmailValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
+@pytest.mark.asyncio
+async def test_non_disposable():
+    validator = DisposableValidator()
+    result = await validator.validate("user@example.com")
+    assert result.status == ValidationStatus.VALID

--- a/tests/test_dns_mx.py
+++ b/tests/test_dns_mx.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from dns.resolver import NXDOMAIN, NoAnswer
 from email_validator_tool.validators.dns_mx import check
-from email_validator_tool.models import ValidationStatus
+from email_validator_tool.core.models import ValidationStatus
 
 @pytest.mark.asyncio
 async def test_valid_mx_records():

--- a/tests/test_role_account.py
+++ b/tests/test_role_account.py
@@ -1,48 +1,15 @@
-"""
-Tests for the role account validator.
-"""
-
 import pytest
 from email_validator_tool.validators.role_account import RoleAccountValidator
+from email_validator_tool.core.models import ValidationStatus
 
-def test_role_account_validator_initialization():
-    """Test role account validator initialization."""
+@pytest.mark.asyncio
+async def test_role_account_detected():
     validator = RoleAccountValidator()
-    assert validator is not None
-    assert validator.name == "role_account"
+    result = await validator.validate("admin@example.com")
+    assert result.status == ValidationStatus.ROLE_ACCOUNT
 
-def test_role_account_validation(valid_email, validation_result):
-    """Test role account validation with a valid email."""
+@pytest.mark.asyncio
+async def test_regular_account():
     validator = RoleAccountValidator()
-    result = validator.validate(valid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is True
-
-def test_role_account_validation_with_role_account(role_account_email, validation_result):
-    """Test role account validation with a role account email."""
-    validator = RoleAccountValidator()
-    result = validator.validate(role_account_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_role_account_validation_with_common_role_accounts(validation_result):
-    """Test role account validation with common role account emails."""
-    validator = RoleAccountValidator()
-    role_accounts = [
-        "admin@example.com",
-        "support@example.com",
-        "info@example.com",
-        "sales@example.com",
-        "contact@example.com"
-    ]
-    for email in role_accounts:
-        result = validator.validate(email, validation_result)
-        assert isinstance(result, bool)
-        assert result is False
-
-def test_role_account_validation_with_invalid_email(invalid_email, validation_result):
-    """Test role account validation with an invalid email."""
-    validator = RoleAccountValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
+    result = await validator.validate("user@example.com")
+    assert result.status == ValidationStatus.VALID

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -1,47 +1,9 @@
-"""
-Tests for the SMTP email validator.
-"""
-
 import pytest
 from email_validator_tool.validators.smtp import SMTPValidator
+from email_validator_tool.core.models import ValidationStatus
 
-def test_smtp_validator_initialization():
-    """Test SMTP validator initialization."""
+@pytest.mark.asyncio
+async def test_invalid_domain():
     validator = SMTPValidator()
-    assert validator is not None
-    assert validator.name == "smtp"
-
-def test_smtp_validation(valid_email, validation_result):
-    """Test SMTP validation with a valid email."""
-    validator = SMTPValidator()
-    result = validator.validate(valid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is True
-
-def test_smtp_validation_with_invalid_domain(invalid_email, validation_result):
-    """Test SMTP validation with an invalid domain."""
-    validator = SMTPValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_smtp_validation_with_nonexistent_domain(validation_result):
-    """Test SMTP validation with a nonexistent domain."""
-    validator = SMTPValidator()
-    result = validator.validate("test@nonexistentdomain123456.com", validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_smtp_validation_with_timeout(validation_result):
-    """Test SMTP validation with a timeout."""
-    validator = SMTPValidator(timeout=0.1)  # Very short timeout
-    result = validator.validate("test@example.com", validation_result)
-    assert isinstance(result, bool)
-    assert result is False
-
-def test_smtp_validation_with_invalid_email(invalid_email, validation_result):
-    """Test SMTP validation with an invalid email."""
-    validator = SMTPValidator()
-    result = validator.validate(invalid_email, validation_result)
-    assert isinstance(result, bool)
-    assert result is False
+    result = await validator.validate("user@invalid-domain.test")
+    assert result.status in {ValidationStatus.INVALID_DOMAIN, ValidationStatus.UNKNOWN_ERROR}

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,6 +1,6 @@
 import pytest
 from email_validator_tool.validators.syntax import check
-from email_validator_tool.models import ValidationStatus
+from email_validator_tool.core.models import ValidationStatus
 
 @pytest.mark.asyncio
 async def test_valid_syntax():


### PR DESCRIPTION
## Summary
- drop Debounce API reliance and rely on local checks
- update validators for disposable domains, bounce list, and catch-all
- add convenience `check` helpers
- simplify tests for async validators

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68534732273c8331aefa9842d8fc24e3